### PR TITLE
Jacob's Makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## Makefile build dir
+out
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,49 @@
 # Metadata File (LaTeX header code to allow editing theme options, titlegraphic) 
-METADATA=metadata.yml
-# Pandoc flags
-# Currently: -t beamer (template beamer) --metadata-file (sets metadata-file) -o (set output to file) 
-PANDOC_FLAGS := -t beamer
-PANDOC_FLAGS += --metadata-file $(METADATA)
+METADATA ?= metadata.yml
+
+# Source file directory
+SRC_DIR ?= src
+
+# Target/Build directory for PDF files
+OUT_DIR ?= out
+
+# Pandoc flags, currently: -t beamer (template beamer) --metadata-file (sets metadata-file) -o (set output to file)
+PANDOC_FLAGS = -t beamer --metadata-file "$(METADATA)"
+
 # Pandoc Command up until variable file name src and dest
-PANDOC := pandoc $(PANDOC_FLAGS) 
+PANDOC = pandoc $(PANDOC_FLAGS) 
+
+# Below assignments are immediate-to-immediate in unlikely case files change after make starts.
+# Avoids broken states.
+
+# Markdown source files
+SRC_MD := $(wildcard $(SRC_DIR)/*.md)
+# Org Mode source files
+SRC_ORG := $(wildcard $(SRC_DIR)/*.org)
+
+# Generate target PDF files from source files by rewriting file extensions.
+# .md => .pdf
+PDFS := $(patsubst ${SRC_DIR}/%.md, ${OUT_DIR}/%.pdf, ${SRC_MD})
+# .org => .pdf
+PDFS += $(patsubst ${SRC_DIR}/%.org, ${OUT_DIR}/%.pdf, ${SRC_ORG})
+
+.PHONY: all clean
+
+# `all` builds PDFs from .md & .org files
+all : $(PDFS)
 
 # Markdown to PDF Rule
-%.pdf : %.md
-	$(PANDOC) $< -o $@
+$(OUT_DIR)/%.pdf : $(SRC_DIR)/%.md
+	# -p flag = parents = make parent directories as needed.
+	# "$(@D)" = Directory part of target's filename.
+	# mkdir -p "$(@D)" = Make OUT_DIR if it doesn't exist, otherwise ignore
+	mkdir -p "$(@D)"
+	$(PANDOC) "$<" -o "$@"
 
 # Org Mode Support (Untested)
-%.pdf : %.org
-	$(PANDOC) $< -o $@
+$(OUT_DIR)/%.pdf : $(SRC_DIR)/%.org
+	mkdir -p "$(@D)"
+	$(PANDOC) "$<" -o "$@"
+
+clean:
+	$(RM) -r "$(OUT_DIR)"


### PR DESCRIPTION
Jacob very kindly upgraded this Makefile in another repo which uses this theme. His changes included:

- Making the `METADATA` variable overridable with the following syntax: `make METADATA=something_else.yml`, wherein `something_else.yml` is the overridden metadata file.
- Changing how assignments are made to avoid conflicts in the edge case that file types are changed after make is ran.
- Using source (`src`) and build (`out`) folders to allow multiple files to be compiled by make in the same project.
- Adding a clean rule

I added minor comments.